### PR TITLE
Update blog anchor to add http(s) protocol

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -15,7 +15,7 @@
           <br v-if="api.location" />
           <a
             v-if="api.blog"
-            :href="api.blog"
+            :href="/^https?:\/\//.test(api.blog) ? api.blog : 'https://' + api.blog"
             target="_blank"
             style="color: #497094"
             >{{ api.blog ? "📔 " + api.blog : "" }}</a


### PR DESCRIPTION
This PR adds a test to check if a user's blog URL starts with a `http` protocol (`http`/`https`). If it doesn't it automatically adds the protocol.

This is necessary because, without the protocol, the anchor elements for a user's blog redirect to `https://aykutsarac.github.io/github-gram/{user's blog url}` instead of just `{user's blog url}`.

### Example:

my blog URL is just `linktr.ee/matievisthekat`. This is valid for my GitHub profile:

![my github blog url](https://i.imgur.com/0pBAMnN.png)
(clicking on this link redirects to `https://linktr.ee/matievisthekat`)

but not on the site:

![site blog url](https://i.imgur.com/633i4SI.png)
(clicking on this link redirects to `https://aykutsarac.github.io/github-gram/linktr.ee/matievisthekat`)